### PR TITLE
Add Gmail email confirmation service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,10 @@ AGENT_NAME=FTAI Voice Assistant
 LOG_LEVEL=INFO
 
 # Google Calendar (for appointment booking)
-GOOGLE_CALENDAR_ID=your-calendar@gmail.com
+GOOGLE_CALENDAR_ID=your-calendar@yourdomain.com
 GOOGLE_SERVICE_ACCOUNT_FILE=credentials.json
+# For Google Workspace with domain-wide delegation (impersonate this user)
+GOOGLE_DELEGATE_USER=your-email@yourdomain.com
 
 # Gmail SMTP (for confirmation emails)
 # Create an App Password at: https://myaccount.google.com/apppasswords

--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ LOG_LEVEL=INFO
 # Google Calendar (for appointment booking)
 GOOGLE_CALENDAR_ID=your-calendar@gmail.com
 GOOGLE_SERVICE_ACCOUNT_FILE=credentials.json
+
+# Gmail SMTP (for confirmation emails)
+# Create an App Password at: https://myaccount.google.com/apppasswords
+GMAIL_USER=your-email@gmail.com
+GMAIL_APP_PASSWORD=your-app-password
+EMAIL_FROM_NAME=Glow Medical Spa

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ GOOGLE_CALENDAR_ID=your-calendar@yourdomain.com
 GOOGLE_SERVICE_ACCOUNT_FILE=credentials.json
 # For Google Workspace with domain-wide delegation (impersonate this user)
 GOOGLE_DELEGATE_USER=your-email@yourdomain.com
+# Timezone for appointments (default: America/New_York)
+CALENDAR_TIMEZONE=America/New_York
 
 # Gmail SMTP (for confirmation emails)
 # Create an App Password at: https://myaccount.google.com/apppasswords

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ htmlcov/
 # LiveKit
 livekit.yaml
 *.pem
+agent/credentials.json

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -77,6 +77,24 @@ def parse_date(date_str: str) -> datetime:
 
 
 @function_tool()
+async def end_call(
+    context: RunContext,
+    reason: Annotated[str, "Brief reason for ending the call, e.g. 'booking complete', 'caller said goodbye'"],
+) -> str:
+    """End the call after saying goodbye. Use this when the conversation is complete - after a booking is confirmed or when the caller says goodbye."""
+    log(f"[TOOL] end_call called: {reason}")
+
+    # Schedule disconnect after a brief delay to allow final message to play
+    import asyncio
+    async def delayed_disconnect():
+        await asyncio.sleep(3)  # Wait for goodbye message to finish
+        await context.session.aclose()
+
+    asyncio.create_task(delayed_disconnect())
+    return "Call ending. Say a warm goodbye."
+
+
+@function_tool()
 async def check_availability(
     context: RunContext,
     date: Annotated[str, "The date to check availability for, e.g. 'tomorrow', 'Thursday', or 'January 15'"],
@@ -197,7 +215,7 @@ class VoiceAssistant(Agent):
     def __init__(self) -> None:
         super().__init__(
             instructions=config.load_prompt("medspa"),
-            tools=[check_availability, book_appointment],
+            tools=[check_availability, book_appointment, end_call],
         )
 
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -18,6 +18,7 @@ from livekit.plugins import noise_cancellation, silero, openai, deepgram, cartes
 
 from config import config
 from calendar_service import calendar_service
+from email_service import email_service
 
 # Load environment variables
 load_dotenv()
@@ -164,12 +165,29 @@ async def book_appointment(
         )
         if result:
             log(f"[TOOL] Calendar event created: {result}")
+
+            # Send confirmation email
+            email_sent = email_service.send_confirmation_email(
+                customer_name=customer_name,
+                customer_email=customer_email,
+                service_type=service,
+                appointment_date=start_time,
+            )
+            if email_sent:
+                log(f"[TOOL] Confirmation email sent to {customer_email}")
+
             return f"Appointment confirmed! {customer_name} is booked for {service} on {day_name}, {date_str} at {time_str}. A confirmation email has been sent to {customer_email}."
         else:
             return f"I'm sorry, there was an issue booking that time slot. It may have just been taken. Would you like to try a different time?"
 
-    # Fallback if calendar not configured
+    # Fallback if calendar not configured (still try to send email)
     log("[TOOL] Using mock booking (calendar not configured)")
+    email_service.send_confirmation_email(
+        customer_name=customer_name,
+        customer_email=customer_email,
+        service_type=service,
+        appointment_date=start_time,
+    )
     return f"Appointment confirmed! {customer_name} is booked for {service} on {day_name}, {date_str} at {time_str}. A confirmation email will be sent to {customer_email}."
 
 

--- a/agent/calendar_service.py
+++ b/agent/calendar_service.py
@@ -24,6 +24,8 @@ class CalendarService:
         self.credentials_file = os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE", "credentials.json")
         # For domain-wide delegation, impersonate this user
         self.delegate_user = os.getenv("GOOGLE_DELEGATE_USER", self.calendar_id)
+        # Timezone for appointments (default to Eastern)
+        self.timezone = os.getenv("CALENDAR_TIMEZONE", "America/New_York")
         self._service = None
 
     @property
@@ -136,11 +138,11 @@ class CalendarService:
             + (f"\nNotes: {notes}" if notes else ""),
             "start": {
                 "dateTime": start_time.isoformat(),
-                "timeZone": "America/Los_Angeles",
+                "timeZone": self.timezone,
             },
             "end": {
                 "dateTime": end_time.isoformat(),
-                "timeZone": "America/Los_Angeles",
+                "timeZone": self.timezone,
             },
             "attendees": [
                 {"email": customer_email},

--- a/agent/calendar_service.py
+++ b/agent/calendar_service.py
@@ -22,15 +22,21 @@ class CalendarService:
     def __init__(self):
         self.calendar_id = os.getenv("GOOGLE_CALENDAR_ID")
         self.credentials_file = os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE", "credentials.json")
+        # For domain-wide delegation, impersonate this user
+        self.delegate_user = os.getenv("GOOGLE_DELEGATE_USER", self.calendar_id)
         self._service = None
 
     @property
     def service(self):
-        """Lazy-load the Google Calendar service."""
+        """Lazy-load the Google Calendar service with domain-wide delegation."""
         if self._service is None:
             credentials = service_account.Credentials.from_service_account_file(
                 self.credentials_file, scopes=SCOPES
             )
+            # Use domain-wide delegation to impersonate the user
+            if self.delegate_user:
+                credentials = credentials.with_subject(self.delegate_user)
+                print(f"[CALENDAR] Using domain-wide delegation as: {self.delegate_user}")
             self._service = build("calendar", "v3", credentials=credentials)
         return self._service
 

--- a/agent/email_service.py
+++ b/agent/email_service.py
@@ -1,0 +1,191 @@
+"""Email service for sending appointment confirmations via Gmail SMTP."""
+
+import os
+import smtplib
+from datetime import datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Optional
+
+
+class EmailService:
+    """Service for sending emails via Gmail SMTP."""
+
+    def __init__(self):
+        self.smtp_host = os.getenv("SMTP_HOST", "smtp.gmail.com")
+        self.smtp_port = int(os.getenv("SMTP_PORT", "587"))
+        self.smtp_user = os.getenv("GMAIL_USER")
+        self.smtp_password = os.getenv("GMAIL_APP_PASSWORD")
+        self.from_name = os.getenv("EMAIL_FROM_NAME", "Glow Medical Spa")
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if email service is properly configured."""
+        return bool(self.smtp_user and self.smtp_password)
+
+    def send_confirmation_email(
+        self,
+        customer_name: str,
+        customer_email: str,
+        service_type: str,
+        appointment_date: datetime,
+        duration_minutes: int = 60,
+        location: str = "2847 Riverside Drive, Suite 100",
+        phone: str = "(555) 234-5678",
+    ) -> bool:
+        """
+        Send an appointment confirmation email.
+
+        Args:
+            customer_name: Name of the customer
+            customer_email: Customer's email address
+            service_type: Type of service booked
+            appointment_date: Date and time of appointment
+            duration_minutes: Length of appointment
+            location: Spa location address
+            phone: Spa phone number
+
+        Returns:
+            True if email sent successfully, False otherwise
+        """
+        if not self.is_configured:
+            print("[EMAIL] Email service not configured, skipping send")
+            return False
+
+        # Format the date/time nicely
+        date_str = appointment_date.strftime("%A, %B %d, %Y")
+        time_str = appointment_date.strftime("%-I:%M %p")
+        end_time = appointment_date.replace(
+            hour=appointment_date.hour + duration_minutes // 60,
+            minute=appointment_date.minute + duration_minutes % 60,
+        )
+        end_time_str = end_time.strftime("%-I:%M %p")
+
+        subject = f"Appointment Confirmed - {service_type} at {self.from_name}"
+
+        # Create HTML email body
+        html_body = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {{ font-family: Arial, sans-serif; line-height: 1.6; color: #333; }}
+        .container {{ max-width: 600px; margin: 0 auto; padding: 20px; }}
+        .header {{ background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0; }}
+        .content {{ background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px; }}
+        .appointment-details {{ background: white; padding: 20px; border-radius: 8px; margin: 20px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+        .detail-row {{ display: flex; padding: 10px 0; border-bottom: 1px solid #eee; }}
+        .detail-label {{ font-weight: bold; width: 120px; color: #666; }}
+        .footer {{ text-align: center; padding: 20px; color: #888; font-size: 12px; }}
+        .button {{ display: inline-block; background: #667eea; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; margin-top: 20px; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>{self.from_name}</h1>
+            <p>Appointment Confirmation</p>
+        </div>
+        <div class="content">
+            <p>Hi {customer_name},</p>
+            <p>Your appointment has been confirmed! Here are your booking details:</p>
+
+            <div class="appointment-details">
+                <div class="detail-row">
+                    <span class="detail-label">Service:</span>
+                    <span>{service_type}</span>
+                </div>
+                <div class="detail-row">
+                    <span class="detail-label">Date:</span>
+                    <span>{date_str}</span>
+                </div>
+                <div class="detail-row">
+                    <span class="detail-label">Time:</span>
+                    <span>{time_str} - {end_time_str}</span>
+                </div>
+                <div class="detail-row">
+                    <span class="detail-label">Location:</span>
+                    <span>{location}</span>
+                </div>
+            </div>
+
+            <p><strong>What to expect:</strong></p>
+            <ul>
+                <li>Please arrive 10-15 minutes early to complete any paperwork</li>
+                <li>Wear comfortable clothing</li>
+                <li>Let us know if you have any questions beforehand</li>
+            </ul>
+
+            <p>Need to reschedule or cancel? Please call us at {phone} at least 24 hours in advance.</p>
+
+            <p>We look forward to seeing you!</p>
+
+            <p>Warm regards,<br>The {self.from_name} Team</p>
+        </div>
+        <div class="footer">
+            <p>{self.from_name}<br>{location}<br>{phone}</p>
+        </div>
+    </div>
+</body>
+</html>
+"""
+
+        # Create plain text version
+        text_body = f"""
+Appointment Confirmation - {self.from_name}
+
+Hi {customer_name},
+
+Your appointment has been confirmed!
+
+APPOINTMENT DETAILS:
+- Service: {service_type}
+- Date: {date_str}
+- Time: {time_str} - {end_time_str}
+- Location: {location}
+
+WHAT TO EXPECT:
+- Please arrive 10-15 minutes early to complete any paperwork
+- Wear comfortable clothing
+- Let us know if you have any questions beforehand
+
+Need to reschedule or cancel? Please call us at {phone} at least 24 hours in advance.
+
+We look forward to seeing you!
+
+Warm regards,
+The {self.from_name} Team
+
+---
+{self.from_name}
+{location}
+{phone}
+"""
+
+        try:
+            # Create message
+            msg = MIMEMultipart("alternative")
+            msg["Subject"] = subject
+            msg["From"] = f"{self.from_name} <{self.smtp_user}>"
+            msg["To"] = customer_email
+
+            # Attach both plain text and HTML versions
+            msg.attach(MIMEText(text_body, "plain"))
+            msg.attach(MIMEText(html_body, "html"))
+
+            # Send email
+            with smtplib.SMTP(self.smtp_host, self.smtp_port) as server:
+                server.starttls()
+                server.login(self.smtp_user, self.smtp_password)
+                server.send_message(msg)
+
+            print(f"[EMAIL] Confirmation sent to {customer_email}")
+            return True
+
+        except Exception as e:
+            print(f"[EMAIL] Error sending email: {e}")
+            return False
+
+
+# Singleton instance
+email_service = EmailService()

--- a/agent/prompts/medspa.txt
+++ b/agent/prompts/medspa.txt
@@ -32,3 +32,7 @@ When booking appointments:
 Keep your responses concise and conversational - aim for 1-2 sentences unless more detail is specifically needed. Be warm, professional, and reassuring since many callers may be nervous about their first treatment.
 
 Remember: This is a voice conversation, so avoid using markdown, bullet points, or other text formatting. Speak naturally as you would on a real phone call.
+
+Important: When using tools, never speak the tool name or parameters aloud. Just use the tool silently and then respond naturally with the results. For example, don't say "Let me check availability" and then read out function names - just check and tell them the available times.
+
+After completing a booking or when the caller says goodbye, use the end_call tool to properly end the conversation. Say a warm farewell first, then end the call.

--- a/agent/test_calendar.py
+++ b/agent/test_calendar.py
@@ -1,0 +1,75 @@
+"""Quick test script for calendar integration."""
+
+import os
+import sys
+from datetime import datetime, timedelta
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Add parent dir to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from calendar_service import calendar_service
+
+def test_calendar():
+    print("=" * 50)
+    print("Testing Google Calendar Integration")
+    print("=" * 50)
+
+    # Check config
+    print(f"\nCalendar ID: {calendar_service.calendar_id}")
+    print(f"Delegate User: {calendar_service.delegate_user}")
+    print(f"Credentials File: {calendar_service.credentials_file}")
+
+    if not calendar_service.calendar_id:
+        print("\n❌ GOOGLE_CALENDAR_ID not set in .env")
+        return
+
+    # Test 1: Check availability for tomorrow
+    print("\n--- Test 1: Checking availability for tomorrow ---")
+    tomorrow = datetime.now() + timedelta(days=1)
+
+    # Skip to next open day if tomorrow is Sunday or Monday
+    while tomorrow.weekday() in [6, 0]:
+        tomorrow += timedelta(days=1)
+
+    print(f"Checking: {tomorrow.strftime('%A, %B %d')}")
+
+    try:
+        slots = calendar_service.get_available_slots(tomorrow)
+        if slots:
+            print(f"✅ Available slots: {', '.join(slots[:5])}")
+        else:
+            print("⚠️  No available slots (calendar may be fully booked)")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        return
+
+    # Test 2: Create a test appointment (optional)
+    print("\n--- Test 2: Create test appointment? ---")
+    response = input("Create a test appointment? (y/n): ").strip().lower()
+
+    if response == 'y':
+        test_time = tomorrow.replace(hour=15, minute=0, second=0, microsecond=0)
+        print(f"Creating appointment for {test_time.strftime('%A, %B %d at %-I:%M %p')}")
+
+        result = calendar_service.create_appointment(
+            customer_name="Test Customer",
+            customer_email=calendar_service.calendar_id,  # Send to yourself
+            service_type="Test Appointment",
+            start_time=test_time,
+            duration_minutes=30,
+        )
+
+        if result:
+            print(f"✅ Appointment created!")
+            print(f"   Link: {result.get('link')}")
+        else:
+            print("❌ Failed to create appointment")
+
+    print("\n" + "=" * 50)
+    print("Test complete!")
+
+if __name__ == "__main__":
+    test_calendar()

--- a/agent/test_email.py
+++ b/agent/test_email.py
@@ -1,0 +1,52 @@
+"""Quick test script for email service."""
+
+import os
+import sys
+from datetime import datetime, timedelta
+from dotenv import load_dotenv
+
+load_dotenv()
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from email_service import email_service
+
+def test_email():
+    print("=" * 50)
+    print("Testing Gmail Email Service")
+    print("=" * 50)
+
+    print(f"\nGmail User: {email_service.smtp_user}")
+    print(f"Configured: {'Yes' if email_service.is_configured else 'No'}")
+
+    if not email_service.is_configured:
+        print("\n❌ Email not configured. Set GMAIL_USER and GMAIL_APP_PASSWORD in .env")
+        return
+
+    # Test sending email
+    print("\n--- Sending test confirmation email ---")
+
+    test_email_to = input(f"Send test email to (default: {email_service.smtp_user}): ").strip()
+    if not test_email_to:
+        test_email_to = email_service.smtp_user
+
+    tomorrow = datetime.now() + timedelta(days=1)
+    test_time = tomorrow.replace(hour=14, minute=0, second=0, microsecond=0)
+
+    success = email_service.send_confirmation_email(
+        customer_name="Test Customer",
+        customer_email=test_email_to,
+        service_type="HydraFacial",
+        appointment_date=test_time,
+        duration_minutes=45,
+    )
+
+    if success:
+        print(f"✅ Email sent to {test_email_to}")
+    else:
+        print("❌ Failed to send email")
+
+    print("\n" + "=" * 50)
+
+if __name__ == "__main__":
+    test_email()


### PR DESCRIPTION
## Summary
- Creates `email_service.py` for sending appointment confirmations via Gmail SMTP
- Professional HTML email template with booking details
- Plain text fallback for email clients that don't support HTML
- Integrated into `book_appointment` tool - emails sent automatically after booking

## Setup Required
1. Enable 2-Factor Authentication on your Gmail account
2. Create an App Password at https://myaccount.google.com/apppasswords
3. Set environment variables:
   - `GMAIL_USER` - your Gmail address
   - `GMAIL_APP_PASSWORD` - the generated app password
   - `EMAIL_FROM_NAME` - display name (e.g., "Glow Medical Spa")

## Test plan
- [ ] Test with mock booking (no email configured) - should not crash
- [ ] Test with valid Gmail credentials
- [ ] Verify HTML email renders correctly
- [ ] Verify plain text fallback works